### PR TITLE
fixed the behavior of the validation method on the emulator

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -63,7 +63,7 @@ export class BaseAuth {
     const isEmulator = useEmulator(env);
     const decodedIdToken = await this.idTokenVerifier.verifyJWT(idToken, isEmulator);
     // Whether to check if the token was revoked.
-    if (checkRevoked || isEmulator) {
+    if (checkRevoked) {
       return await this.verifyDecodedJWTNotRevokedOrDisabled(decodedIdToken, AuthClientErrorCode.ID_TOKEN_REVOKED, env);
     }
     return decodedIdToken;
@@ -137,7 +137,7 @@ export class BaseAuth {
     const isEmulator = useEmulator(env);
     const decodedIdToken = await this.sessionCookieVerifier.verifyJWT(sessionCookie, isEmulator);
     // Whether to check if the token was revoked.
-    if (checkRevoked || isEmulator) {
+    if (checkRevoked) {
       return await this.verifyDecodedJWTNotRevokedOrDisabled(
         decodedIdToken,
         AuthClientErrorCode.SESSION_COOKIE_REVOKED,

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -79,10 +79,7 @@ describe('createSessionCookie()', () => {
 
     await new Promise(resolve => setTimeout(() => resolve(auth.revokeRefreshTokens(uid2, env)), 1000));
 
-    // Check revocation is forced in emulator-mode and this should throw.
-    await expect(auth.verifySessionCookie(sessionCookie, false, env)).rejects.toThrowError(
-      new FirebaseAuthError(AuthClientErrorCode.SESSION_COOKIE_REVOKED)
-    );
+    await expect(auth.verifySessionCookie(sessionCookie, false, env)).resolves.toHaveProperty('uid', uid2);
 
     await expect(auth.verifySessionCookie(sessionCookie, true, env)).rejects.toThrowError(
       new FirebaseAuthError(AuthClientErrorCode.SESSION_COOKIE_REVOKED)
@@ -166,10 +163,7 @@ describe('verifySessionCookie()', () => {
     expect(userRecord.uid).to.equal(uid);
     expect(userRecord.disabled).to.equal(true);
 
-    // If it is in emulator mode, a user-disabled error will be thrown.
-    await expect(auth.verifySessionCookie(sessionCookie, false, env)).rejects.toThrowError(
-      new FirebaseAuthError(AuthClientErrorCode.USER_DISABLED)
-    );
+    await expect(auth.verifySessionCookie(sessionCookie, false, env)).resolves.toHaveProperty('uid', uid);
 
     await expect(auth.verifySessionCookie(sessionCookie, true, env)).rejects.toThrowError(
       new FirebaseAuthError(AuthClientErrorCode.USER_DISABLED)


### PR DESCRIPTION
fixed so that on the emulator, it does not check whether it's revoked unless the 'checkRevoked' flag is present