### PR TITLE
fixed iat error of 1 second earlier

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -54,14 +54,15 @@ export class BaseAuth {
    * @param env - An optional parameter specifying the environment in which the function is running.
    *   If the function is running in an emulator environment, this should be set to `EmulatorEnv`.
    *   If not specified, the function will assume it is running in a production environment.
-   *
+   * @param clockSkewSeconds - The number of seconds to tolerate when checking the `iat`.
+   *   This is to deal with small clock differences among different servers.
    * @returns A promise fulfilled with the
    *   token's decoded claims if the ID token is valid; otherwise, a rejected
    *   promise.
    */
-  public async verifyIdToken(idToken: string, checkRevoked = false, env?: EmulatorEnv): Promise<FirebaseIdToken> {
+  public async verifyIdToken(idToken: string, checkRevoked = false, env?: EmulatorEnv, clockSkewSeconds?: number): Promise<FirebaseIdToken> {
     const isEmulator = useEmulator(env);
-    const decodedIdToken = await this.idTokenVerifier.verifyJWT(idToken, isEmulator);
+    const decodedIdToken = await this.idTokenVerifier.verifyJWT(idToken, isEmulator, clockSkewSeconds);
     // Whether to check if the token was revoked.
     if (checkRevoked) {
       return await this.verifyDecodedJWTNotRevokedOrDisabled(decodedIdToken, AuthClientErrorCode.ID_TOKEN_REVOKED, env);

--- a/src/token-verifier.ts
+++ b/src/token-verifier.ts
@@ -229,7 +229,7 @@ export class FirebaseTokenVerifier {
    * @param clockSkewSeconds - The number of seconds to tolerate when checking the token's iat. Must be between 0-60, and an integer. Defualts to 0.
    * @returns A promise fulfilled with the decoded claims of the Firebase Auth ID token.
    */
-  public verifyJWT(jwtToken: string, isEmulator = false, clockSkewSeconds: number = 0): Promise<FirebaseIdToken> {
+  public verifyJWT(jwtToken: string, isEmulator = false, clockSkewSeconds: number = 5): Promise<FirebaseIdToken> {
     if (!isString(jwtToken)) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
@@ -243,13 +243,13 @@ export class FirebaseTokenVerifier {
         'clockSkewSeconds must be an integer between 0 and 60.'
       )
     }
-    return this.decodeAndVerify(jwtToken, isEmulator, 0).then(payload => {
+    return this.decodeAndVerify(jwtToken, isEmulator, clockSkewSeconds).then(payload => {
       payload.uid = payload.sub;
       return payload;
     });
   }
 
-  private async decodeAndVerify(token: string, isEmulator: boolean, clockSkewSeconds: number = 0): Promise<FirebaseIdToken> {
+  private async decodeAndVerify(token: string, isEmulator: boolean, clockSkewSeconds: number = 5): Promise<FirebaseIdToken> {
     const currentTimestamp = Math.floor(Date.now() / 1000) + clockSkewSeconds;
     try {
       const rs256Token = this.safeDecode(token, isEmulator, currentTimestamp);

--- a/src/token-verifier.ts
+++ b/src/token-verifier.ts
@@ -226,23 +226,31 @@ export class FirebaseTokenVerifier {
    *
    * @param jwtToken - The Firebase Auth JWT token to verify.
    * @param isEmulator - Whether to accept Auth Emulator tokens.
+   * @param clockSkewSeconds - The number of seconds to tolerate when checking the token's iat. Must be between 0-60, and an integer. Defualts to 0.
    * @returns A promise fulfilled with the decoded claims of the Firebase Auth ID token.
    */
-  public verifyJWT(jwtToken: string, isEmulator = false): Promise<FirebaseIdToken> {
+  public verifyJWT(jwtToken: string, isEmulator = false, clockSkewSeconds: number = 0): Promise<FirebaseIdToken> {
     if (!isString(jwtToken)) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
         `First argument to ${this.tokenInfo.verifyApiName} must be a ${this.tokenInfo.jwtName} string.`
       );
     }
-    return this.decodeAndVerify(jwtToken, isEmulator).then(payload => {
+
+    if (clockSkewSeconds < 0 || clockSkewSeconds > 60 || !Number.isInteger(clockSkewSeconds)) {
+      throw new FirebaseAuthError(
+        AuthClientErrorCode.INVALID_ARGUMENT,
+        'clockSkewSeconds must be an integer between 0 and 60.'
+      )
+    }
+    return this.decodeAndVerify(jwtToken, isEmulator, 0).then(payload => {
       payload.uid = payload.sub;
       return payload;
     });
   }
 
-  private async decodeAndVerify(token: string, isEmulator: boolean): Promise<FirebaseIdToken> {
-    const currentTimestamp = Math.ceil(Date.now() / 1000);
+  private async decodeAndVerify(token: string, isEmulator: boolean, clockSkewSeconds: number = 0): Promise<FirebaseIdToken> {
+    const currentTimestamp = Math.floor(Date.now() / 1000) + clockSkewSeconds;
     try {
       const rs256Token = this.safeDecode(token, isEmulator, currentTimestamp);
       const { payload } = rs256Token.decodedToken;

--- a/src/token-verifier.ts
+++ b/src/token-verifier.ts
@@ -242,7 +242,7 @@ export class FirebaseTokenVerifier {
   }
 
   private async decodeAndVerify(token: string, isEmulator: boolean): Promise<FirebaseIdToken> {
-    const currentTimestamp = Math.floor(Date.now() / 1000);
+    const currentTimestamp = Math.ceil(Date.now() / 1000);
     try {
       const rs256Token = this.safeDecode(token, isEmulator, currentTimestamp);
       const { payload } = rs256Token.decodedToken;


### PR DESCRIPTION
# Error I encountered
I have encountered an issue with token verification where the iat claim is consistently 1 second ahead of the calculated current timestamp, resulting in verification errors. 
```
Decoding Firebase ID token failed. Make sure you passed the entire string JWT
  which represents an ID token. See https://firebase.google.com/docs/auth/admin/verify-id-tokens for
  details on how to retrieve an ID token. err: Error: Incorrect "iat" claim must be a older than
  "1718141274" (iat: "1718141275")
```

# Solution

I do not know the reason why, but I guess there is an calculation mismatch under 1000ms.
I tested in my environment and figured out that Math.ceil fixes this problem to round the timestamp.

# Justification

Honestly I do not know whether iat verification should be strict or not, however, I found that the same error is previously discussed on this Python repository and PR got merged.
https://github.com/firebase/firebase-admin-python/pull/714
So IMO there is no reason to be strict and Math.ceil is somewhat valid solution.

Perhaps this error should be fixed comprehensively by adding clockSkewInSeconds args.