### PR TITLE
Fix ID token and session token JWK conflcit in KV store

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,7 +4,7 @@ import type { EmulatorEnv } from './emulator';
 import { useEmulator } from './emulator';
 import type { ErrorInfo } from './errors';
 import { AppErrorCodes, AuthClientErrorCode, FirebaseAppError, FirebaseAuthError } from './errors';
-import type { KeyStorer } from './key-store';
+import { scopedKeyStorer, type KeyStorer } from './key-store';
 import type { FirebaseIdToken, FirebaseTokenVerifier } from './token-verifier';
 import { createIdTokenVerifier, createSessionCookieVerifier } from './token-verifier';
 import type { UserRecord } from './user-record';
@@ -17,8 +17,8 @@ export class BaseAuth {
   private readonly _authApiClient?: AuthApiClient;
 
   constructor(projectId: string, keyStore: KeyStorer, credential?: Credential) {
-    this.idTokenVerifier = createIdTokenVerifier(projectId, keyStore);
-    this.sessionCookieVerifier = createSessionCookieVerifier(projectId, keyStore);
+    this.idTokenVerifier = createIdTokenVerifier(projectId, scopedKeyStorer(keyStore, 'id-token'));
+    this.sessionCookieVerifier = createSessionCookieVerifier(projectId, scopedKeyStorer(keyStore, 'session-cookie'));
 
     if (credential) {
       this._authApiClient = new AuthApiClient(projectId, credential);

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,10 @@ export class WorkersKVStoreSingle extends WorkersKVStore {
     super(cacheKey, cfKVNamespace);
   }
 
+  public scoped(scope: string): WorkersKVStoreSingle {
+    return WorkersKVStoreSingle.getOrInitialize(`${this.cacheKey}:${scope}`, this.cfKVNamespace);
+  }
+
   static getOrInitialize(cacheKey: string, cfKVNamespace: KVNamespace): WorkersKVStoreSingle {
     if (!WorkersKVStoreSingle.instance) {
       WorkersKVStoreSingle.instance = new Map<string, WorkersKVStoreSingle>();

--- a/src/key-store.ts
+++ b/src/key-store.ts
@@ -1,6 +1,14 @@
 export interface KeyStorer {
   get<ExpectedValue = unknown>(): Promise<ExpectedValue | null>;
   put(value: string, expirationTtl: number): Promise<void>;
+  scoped?(scope: string): KeyStorer;
+}
+
+export function scopedKeyStorer(keyStorer: KeyStorer, scope: string): KeyStorer {
+  if (typeof keyStorer.scoped === 'function') {
+    return keyStorer.scoped(scope);
+  }
+  return keyStorer;
 }
 
 /**
@@ -8,9 +16,16 @@ export interface KeyStorer {
  */
 export class WorkersKVStore implements KeyStorer {
   constructor(
-    private readonly cacheKey: string,
-    private readonly cfKVNamespace: KVNamespace
+    protected readonly cacheKey: string,
+    protected readonly cfKVNamespace: KVNamespace
   ) {}
+
+  /**
+   * Returns a view of this store that caches public keys under a derived KV key.
+   */
+  public scoped(scope: string): WorkersKVStore {
+    return new WorkersKVStore(`${this.cacheKey}:${scope}`, this.cfKVNamespace);
+  }
 
   public async get<ExpectedValue = unknown>(): Promise<ExpectedValue | null> {
     return await this.cfKVNamespace.get<ExpectedValue>(this.cacheKey, 'json');

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ApiSettings } from '../src/api-requests';
 import { BaseAuth } from '../src/auth';
 import { AuthApiClient } from '../src/auth-api-requests';
@@ -23,6 +23,28 @@ const sessionCookieUids = [
   generateRandomString(20),
   generateRandomString(20),
 ];
+
+describe('BaseAuth key store scoping', () => {
+  it('scopes key store separately for id-token and session-cookie verifiers', () => {
+    const scoped = vi.fn(
+      (_scope: string): KeyStorer => ({
+        get: vi.fn(),
+        put: vi.fn(),
+      })
+    );
+    const keyStorer: KeyStorer = {
+      get: vi.fn(),
+      put: vi.fn(),
+      scoped,
+    };
+
+    new BaseAuth(projectId, keyStorer);
+
+    expect(scoped).toHaveBeenCalledTimes(2);
+    expect(scoped).toHaveBeenCalledWith('id-token');
+    expect(scoped).toHaveBeenCalledWith('session-cookie');
+  });
+});
 
 describe('createSessionCookie()', () => {
   const expiresIn = 24 * 60 * 60 * 1000;

--- a/tests/key-store.test.ts
+++ b/tests/key-store.test.ts
@@ -1,0 +1,43 @@
+import { Miniflare } from 'miniflare';
+import { describe, expect, it } from 'vitest';
+import { WorkersKVStoreSingle } from '../src/index';
+import { WorkersKVStore } from '../src/key-store';
+
+const nullScript = 'export default { fetch: () => new Response(null, { status: 404 }) };';
+const mf = new Miniflare({
+  modules: true,
+  script: nullScript,
+  kvNamespaces: ['TEST_NAMESPACE'],
+});
+
+describe('WorkersKVStore.scoped', () => {
+  it('suffixes the KV key with the scope', async () => {
+    const TEST_NAMESPACE = await mf.getKVNamespace('TEST_NAMESPACE');
+    const baseKey = 'scoped-cache-key';
+    const keyStore = new WorkersKVStore(baseKey, TEST_NAMESPACE);
+
+    const idTokenStore = keyStore.scoped('id-token');
+    const sessionCookieStore = keyStore.scoped('session-cookie');
+
+    await idTokenStore.put(JSON.stringify([{ kid: 'id-kid' }]), 3600);
+    await sessionCookieStore.put(JSON.stringify([{ kid: 'session-kid' }]), 3600);
+
+    expect(await TEST_NAMESPACE.get(`${baseKey}:id-token`, 'json')).toEqual([{ kid: 'id-kid' }]);
+    expect(await TEST_NAMESPACE.get(`${baseKey}:session-cookie`, 'json')).toEqual([{ kid: 'session-kid' }]);
+    expect(await TEST_NAMESPACE.get(baseKey)).toBeNull();
+  });
+});
+
+describe('WorkersKVStoreSingle.scoped', () => {
+  it('returns a singleton per scoped cache key', async () => {
+    const TEST_NAMESPACE = await mf.getKVNamespace('TEST_NAMESPACE');
+    const keyStore = WorkersKVStoreSingle.getOrInitialize('base-key', TEST_NAMESPACE);
+
+    const idTokenStore = keyStore.scoped('id-token');
+    const idTokenStoreAgain = keyStore.scoped('id-token');
+    const sessionCookieStore = keyStore.scoped('session-cookie');
+
+    expect(idTokenStore).toBe(idTokenStoreAgain);
+    expect(sessionCookieStore).not.toBe(idTokenStore);
+  });
+});


### PR DESCRIPTION
Fixes #31

## Overview

ID token verifier and session cookie verifier use different and incompatible signing keys in the same cache entry.

Verifying an ID token prevents verifying session cookies and vice versa.

This PR adds a `.scoped(scope)` function to the store that adds a `:id-token` and `:session-cookie` suffix to the provided cache key, so that both verification methods can work at the same time.

## Problem

The current implementation uses a signle `WorkersKVStore` for the user-provided KV key. Both the ID token verifier and session cookie verifier use this same store, but they each need a different JWK.

The ID token verification keys are fetched from
<https://www.googleapis.com/robot/v1/metadata/jwk/securetoken@system.gserviceaccount.com> while the session cookie verification keys are fetched from <https://www.googleapis.com/identitytoolkit/v3/relyingparty/publicKeys>.

Whichever one gets used first gets cached in the KV store, then both ID token and session cookie verifiers will use those same cached keys until TTL expires. This means one of them will get the wrong keys and reject all verifications.

## Solution

This PR fixes this. I tried to go with the approach that is the least breaking possible. I didn't want to change the public interface of `Auth` nor `WorkersKVStore`.

Instead this PR adds a `scoped(scope: string)` function to `KeyStorer` (optional for backwards compatibility), and implements it in both `WorkersKVStore` and `WorkersKVStoreSingle`. It returns an instance of the same class with `:${scope}` appended to the original key.

In the case of `WorkersKVStoreSingle`, `.scoped()` also registers a singleton for that scope.

Then in `BaseAuth`, we scope the `KeyStorer` in the contructor:

```js
function scopedKeyStorer(keyStorer: KeyStorer, scope: string): KeyStorer {
  if (typeof keyStorer.scoped === 'function') {
    return keyStorer.scoped(scope);
  }
  return keyStorer;
}

this.idTokenVerifier = createIdTokenVerifier(projectId, scopedKeyStorer(keyStore, 'id-token'));
this.sessionCookieVerifier = createSessionCookieVerifier(projectId, scopedKeyStorer(keyStore, 'session-cookie'));
```

Note: the `scopedKeyStorer` function is used in case the user passes a custom `KeyStorer` that doesn't have the `scoped` method we just added. Then it'll work just like before with the ID token and session cookie conflict.

## Backwards compatibility

Upgrading to this patched version will result in the previous cache key being ignored, and the appropriate keys to be fetched in the new scoped stores on first use. The previous cache key will stay in the KV until its TTL, then it'll be garbage collected without any manual cleanup necessary.


## Notes

<details>

<summary>In order to run the test suite with Node 26 and pnpm 11, I've had to add the following patch (not committed here):</summary>

```diff
diff --git a/pnpm-workspace.yaml b/pnpm-workspace.yaml
new file mode 100644
index 0000000..75aa0ab
--- /dev/null
+++ b/pnpm-workspace.yaml
@@ -0,0 +1,8 @@
+allowBuilds:
+  esbuild: true
+  protobufjs: true
+  re2: true
+  workerd: true
+
+overrides:
+  jwa: 2.0.1
diff --git a/tests/setup.ts b/tests/setup.ts
index 9f628c5..a8dc0c0 100644
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,9 +1,10 @@
 import crypto from 'node:crypto';
-import { setGlobalDispatcher } from 'undici';
+import { fetch as undiciFetch, setGlobalDispatcher } from 'undici';
 import { vi, beforeAll, afterAll } from 'vitest';
 import { fetchMock } from './fetch';

 vi.stubGlobal('crypto', crypto);
+vi.stubGlobal('fetch', undiciFetch);

 beforeAll(() => {
   setGlobalDispatcher(fetchMock);
```

</details>

All tests are green.

This PR was AI-assisted but I've carefully steered and reviewed the code, including the new tests. PR description written by hand.

Happy to revisit with a different approach if you think there's a better way to solve this.

Also no rush for merging this, just gonna use my fork in the meantime for my own projects.